### PR TITLE
ci(travis): remove node 9 as build target for travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "9"
   - "10"
 dist: trusty
 sudo: required

--- a/libs/rhetos/src/lib/rest-services/rest-service-factory.ts
+++ b/libs/rhetos/src/lib/rest-services/rest-service-factory.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core';
-import { ComplexEntityInfo, FunctionInfo, StructureInfo } from '../data-structures/info';
+import {
+  ComplexEntityInfo,
+  FunctionInfo,
+  StructureInfo
+} from '../data-structures/info';
 import { ActionService } from './action-service';
 import { ComplexEntityService } from './complex-entity';
 import { FunctionService } from './function-service';
@@ -24,10 +28,18 @@ export class StructureServiceFactory {
   }
 
   createFunctionService<T, R>(info: FunctionInfo<T, R>) {
-    return new FunctionService<T, R>(info.reqInfo.key, info.resInfo.key, this.base);
+    return new FunctionService<T, R>(
+      info.reqInfo.key,
+      info.resInfo.key,
+      this.base
+    );
   }
 
   createComplexEntityService<T>(info: ComplexEntityInfo<T>) {
-    return new ComplexEntityService<T>(info.key, info.dependentStructureKeys, this.base);
+    return new ComplexEntityService<T>(
+      info.key,
+      info.dependentStructureKeys,
+      this.base
+    );
   }
 }


### PR DESCRIPTION
angular devkit only works on node 10 or higher so node 9 is removed

closes #3